### PR TITLE
Fix to allow running on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function sendSendGrid(options){
         if (file.isBuffer()) {
             sendgrid.getTemplates()
                 .then(function() {
-                    var templateName = file.path.replace(file.cwd, '').substring(1).split('/');
+                    var templateName = file.path.replace(file.cwd, '').substring(1).split(path.sep);
                     html = file.contents;
                     $ = cheerio.load(html);
                     title = $('.title').text().trim();


### PR DESCRIPTION
There is different path delimiter in linux\windows. There was hardcoded linux dellimeter. I suggest to use ```path.sep``` https://nodejs.org/api/path.html#path_path_sep that will correctly split line in all systems.